### PR TITLE
erlang:now is deprecated

### DIFF
--- a/src/edgar.erl
+++ b/src/edgar.erl
@@ -416,7 +416,7 @@ longname_body(Trailing) -> list_to_binary(Trailing ++ padding(size(list_to_binar
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 add1(ArFile, Bin, NameInArchive, Opts) when is_binary(Bin) ->
-    Now = calendar:now_to_local_time(now()),
+    Now = calendar:now_to_local_time(erlang:timestamp()),
     Info = #file_info{size = byte_size(Bin),
 		      type = regular,
 		      access = read_write,


### PR DESCRIPTION
Here is a patch that replaces it with erlang:timestamp which gives exactly the same output. Also see http://erlang.org/doc/apps/erts/time_correction.html for some background information if you want.
